### PR TITLE
Support roam dates

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,7 @@
 import os
 import getpass
 
-AGORA_PATH = os.getenv("AGORA_PATH", os.path.join("/home", getpass.getuser(), "agora"))
+AGORA_PATH = os.getenv('AGORA_PATH', os.path.join('/home', getpass.getuser(), 'agora'))
 AGORA_VERSION = '0.5.3'
 
 # With trailing slash.

--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,7 @@
 import os
 import getpass
 
-AGORA_PATH = os.path.join('/home', getpass.getuser(), 'agora')
+AGORA_PATH = os.getenv("AGORA_PATH", os.path.join("/home", getpass.getuser(), "agora"))
 AGORA_VERSION = '0.5.3'
 
 # With trailing slash.

--- a/app/db.py
+++ b/app/db.py
@@ -187,7 +187,7 @@ def all_nodes(include_journals=True):
 
     # remove journals if so desired.
     if not include_journals:
-        nodes = [node for node in nodes if not re.match('[0-9]+?-[0-9]+?-[0-9]+?', node.wikilink)]
+        nodes = [node for node in nodes if not util.is_journal(node.wikilink)]
 
     # TODO: experiment with other ranking.
     # return sorted(nodes, key=lambda x: -x.size())
@@ -201,7 +201,7 @@ def all_users():
 def all_journals():
     # hack hack.
     nodes = all_nodes()
-    nodes = [node for node in nodes if re.match('[0-9]+?-[0-9]+?-[0-9]+?', node.wikilink)]
+    nodes = [node for node in nodes if util.is_journal(node.wikilink)]
     return sorted(nodes, key=attrgetter('wikilink'), reverse=True)
 
 def nodes_by_wikilink(wikilink):

--- a/app/db.py
+++ b/app/db.py
@@ -57,6 +57,11 @@ class Node:
         # i.e. if two users contribute subnodes titled [[foo]], they both show up when querying node [[foo]].
         self.wikilink = wikilink
         self.uri = wikilink
+        # ensure wikilinks to journal entries are all shown in iso format
+        # (important to do it after self.uri = wikilink to avoid breaking
+        # links)
+        if util.is_journal(wikilink):
+            self.wikilink = util.canonical_wikilink(wikilink)
         self.url = '/node/' + self.uri
         self.subnodes = []
 

--- a/app/util.py
+++ b/app/util.py
@@ -41,11 +41,11 @@ def canonical_wikilink(wikilink):
 def canonical_date(wikilink):
     date = parser.get_date_data(wikilink).date_obj
     try:
-        new_wikilink = date.isoformat().split("T")[0] 
+        wikilink = date.isoformat().split("T")[0]
     except:
         pass
 
-    return new_wikilink
+    return wikilink
 
 
 @lru_cache(maxsize=1)  #memoize this

--- a/app/util.py
+++ b/app/util.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import re
 
 def canonical_wikilink(wikilink):
     # hack hack
@@ -22,3 +23,19 @@ def canonical_wikilink(wikilink):
         .replace('/', '-')
     )
     return wikilink
+
+
+def is_journal(wikilink):
+    date_regexes = [
+        # iso format
+        '[0-9]{4}-[0-9]{2}-[0-9]{2}',
+        # roam format (what a monstrosity!)
+        '(January|February|March|April|May|June|July|August|September|October|November|December) [0-9]{1,2}(st|nd|th), [0-9]{4}',
+        # roam format (sanitzed for filenames)
+        '(january|february|march|april|may|june|july|august|september|october|november|december)-[0-9]{1,2}(st|nd|th)-[0-9]{4}',
+    ]
+
+    # combine all the date regexes into one super regex
+    combined_date_regex = re.compile(f'^({"|".join(date_regexes)})$')
+
+    return combined_date_regex.match(wikilink)

--- a/app/util.py
+++ b/app/util.py
@@ -14,5 +14,11 @@
 
 def canonical_wikilink(wikilink):
     # hack hack
-    wikilink = wikilink.lower().replace(' ', '-').replace('\'', '').replace(',', '')
+    wikilink = (
+        wikilink.lower()
+        .replace(' ', '-')
+        .replace('\'', '')
+        .replace(',', '')
+        .replace('/', '-')
+    )
     return wikilink

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,5 @@ webencodings==0.5.1
 Werkzeug==1.0.1
 WTForms==2.3.3
 zipp==3.4.0
+dateparser==1.0.0
+


### PR DESCRIPTION
Adds support for using journal entires in roam's date format in the agora.

Also some other minor tweaks:
- allow AGORA_PATH to be set via an env var (no `/home` for me since I'm on a mac right now!)
- add `/` to the list of special characters to be sanitized in filenames. This is needed because Roam graphs are likely to have page titles with `/`s in them since that's what roam uses for their namespace feature