### PR TITLE
Add styling for blockquotes

### DIFF
--- a/app/static/css/screen-dark.css
+++ b/app/static/css/screen-dark.css
@@ -54,6 +54,13 @@ nav             { font-family: sans-serif}
 .content {
 }
 
+.content blockquote {
+    padding-left: 0.5em;
+    margin-left: 1em;
+    border-left: 2px solid #bfbfbf;
+    font-style: italic;
+}
+
 .navigation {
     vertical-align: middle;
     overflow-y: auto;


### PR DESCRIPTION
This PR styles blockquotes to distinguish them from standard text.

New style:

![image](https://user-images.githubusercontent.com/172324/133856325-553d2676-7e52-4559-8c6d-4758c5e31474.png)

Old style:

![image](https://user-images.githubusercontent.com/172324/133856409-7a1c55bf-1207-4205-991e-22fcdc2452ac.png)
