### PR TITLE
Headings typography

### DIFF
--- a/app/static/css/screen-dark.css
+++ b/app/static/css/screen-dark.css
@@ -18,9 +18,9 @@
 @import url('https://fonts.googleapis.com/css2?family=Merriweather+Sans&display=swap');
 
 :root {
-    /* Body font size. */
     --base-fontsize: 1rem;
     --header-scale: 1.125;
+    --line-height: 1.618;
 }
 
 html { 
@@ -37,7 +37,6 @@ body {
     overflow-x: hidden; 
     max-width: 60em;
     font-size: var(--base-fontsize);
-    line-height: var(--line-height);
 }
 a               { color: #9fc6e0; }
 nav             { font-family: sans-serif}
@@ -55,7 +54,7 @@ nav             { font-family: sans-serif}
 .logo           { filter: invert(1); vertical-align: middle; width="20" height="20"; }
 
 .content {
-    --line-height: 1.618;
+    line-height: var(--line-height);
 }
 
 /* Format headers */

--- a/app/static/css/screen-dark.css
+++ b/app/static/css/screen-dark.css
@@ -17,6 +17,12 @@
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Merriweather+Sans&display=swap');
 
+:root {
+    --base-fontsize: 1rem;
+    --header-scale: 1.125;
+    --line-height: 1.618;
+}
+
 html { 
     font-family: 'Noto Sans', sans-serif;
     display: flex;
@@ -30,13 +36,10 @@ body {
     color: #bfbfbf; 
     overflow-x: hidden; 
     max-width: 60em;
+    font-size: var(--base-fontsize);
+    line-height: var(--line-height);
 }
 a               { color: #9fc6e0; }
-h1, h2          { color: #bfbfbf; }
-h1, h2          { font-family: 'Merriweather Sans'; margin-top: 0.2em; margin-bottom: 0.2em;}
-h1              { font-size: 1.7em; }
-h2              { font-size: 1.2em; }
-
 nav             { font-family: sans-serif}
 .page           { margin: 2em auto; width: 35em; border: 5px solid #ccc;
                   padding: 0.8em; background: white; }
@@ -52,6 +55,51 @@ nav             { font-family: sans-serif}
 .logo           { filter: invert(1); vertical-align: middle; width="20" height="20"; }
 
 .content {
+}
+
+/* Format headers */
+h1, h2, h3          { color: #bfbfbf; }
+h1, h2, h3          { font-family: 'Merriweather Sans'; }
+
+/* Fix line height when title wraps */
+h1, h2, h3 {
+    line-height: 1.1;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    margin-bottom: 1rem;
+}
+
+h1 {
+    font-size: calc(var(--base-fontsize) * var(--header-scale) * var(--header-scale) * var(--header-scale) * var(--header-scale) * var(--header-scale));
+}
+
+h1:not(:first-child) {
+    margin-top: calc(var(--line-height) * 1.5rem);
+}
+
+h2 {
+    font-size: calc(var(--base-fontsize) * var(--header-scale) * var(--header-scale) * var(--header-scale));
+    margin-top: calc(var(--line-height) * 1.4rem);
+}
+
+h3 {
+    font-size: calc(var(--base-fontsize) * var(--header-scale));
+    margin-top: calc(var(--line-height) * 1.3rem);
+}
+
+h4 {
+    font-size: calc(var(--base-fontsize));
+    margin-top: calc(var(--line-height) * 1.2rem);
+}
+
+h5 {
+    font-size: calc(var(--base-fontsize) / var(--header-scale));
+    margin-top: calc(var(--line-height) * 1.1rem);
+}
+
+h6 {
+    font-size: calc(var(--base-fontsize) / var(--header-scale) / var(--header-scale));
 }
 
 .content blockquote {

--- a/app/static/css/screen-dark.css
+++ b/app/static/css/screen-dark.css
@@ -18,9 +18,9 @@
 @import url('https://fonts.googleapis.com/css2?family=Merriweather+Sans&display=swap');
 
 :root {
+    /* Body font size. */
     --base-fontsize: 1rem;
     --header-scale: 1.125;
-    --line-height: 1.618;
 }
 
 html { 
@@ -55,6 +55,7 @@ nav             { font-family: sans-serif}
 .logo           { filter: invert(1); vertical-align: middle; width="20" height="20"; }
 
 .content {
+    --line-height: 1.618;
 }
 
 /* Format headers */

--- a/app/static/css/screen-light.css
+++ b/app/static/css/screen-light.css
@@ -17,7 +17,7 @@
 @import "screen-dark.css";
 
 body            { background: #eee; color: #000000; overflow-x: hidden;}
-a, h1, h2       { color: #377ba8; }
+a, h1, h2, h3, h4, h5, h6       { color: #377ba8; }
 .logo           { filter: none; vertical-align: middle; width="20" height="20"; }
 
 .node { 


### PR DESCRIPTION
This makes some minor tweaks to the typography of the headings in Agora to make the visual hierarchy a bit clearer.

- headings scale down in size appropriately
- more top margin on headings
- headings all same colour

See https://anagora.org/test-node to see an example.

Before

![image](https://user-images.githubusercontent.com/172324/133922258-6d3a88ae-8c71-4a66-9220-9a854bf5eb7a.png)
![image](https://user-images.githubusercontent.com/172324/133922546-6105af5f-cf47-4e60-af38-4e4279447d4b.png)


After 

![image](https://user-images.githubusercontent.com/172324/133922245-0c5180cc-2204-48e2-9ea1-5fa2b1eec3e0.png)
![image](https://user-images.githubusercontent.com/172324/133922549-c3a6b3a9-bfee-486b-ad25-3860adf6a08a.png)
