### PR TITLE
Support table rendering

### DIFF
--- a/app/render.py
+++ b/app/render.py
@@ -23,6 +23,7 @@ from . import config
 from . import regexes
 from . import util 
 from marko import Markdown, inline
+from marko.ext.gfm import gfm
 from orgpython import to_html
 
 
@@ -48,7 +49,8 @@ class Wikilinks():
     elements = [WikilinkElement]
     renderer_mixins = [WikilinkRendererMixin]
 
-markdown = Markdown(extensions=[Wikilinks])
+markdown = gfm
+markdown.use(Wikilinks)
 
 
 # Org-mode -- simple but, well, bad for now.

--- a/app/static/css/screen-dark.css
+++ b/app/static/css/screen-dark.css
@@ -21,6 +21,9 @@
     --base-fontsize: 1rem;
     --header-scale: 1.125;
     --line-height: 1.618;
+
+    --accent-bg: #2B2B2B;
+    --border: #666;
 }
 
 html {
@@ -520,4 +523,33 @@ input[type="text"] {
 
 #ctzn-login {
     margin-top: 20px;
+}
+
+/* Format tables.  Based on https://github.com/kevquirk/simple.css/. */
+table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 1.5rem 0;
+}
+
+td,
+th {
+    border: 1px solid var(--border);
+    text-align: left;
+    padding: .5rem;
+}
+
+th {
+    background: var(--accent-bg);
+    font-weight: bold;
+}
+
+tr:nth-child(even) {
+    /* Set every other cell slightly darker. Improves readability. */
+    background: var(--accent-bg);
+}
+
+table caption {
+    font-weight: bold;
+    margin-bottom: .5rem;
 }

--- a/app/static/css/screen-light.css
+++ b/app/static/css/screen-light.css
@@ -16,6 +16,11 @@
 
 @import "screen-dark.css";
 
+:root {
+    --accent-bg: #F5F7FF;
+    --border: #D8DAE1;
+}
+
 body            { background: #eee; color: #000000; overflow-x: hidden;}
 a, h1, h2, h3, h4, h5, h6       { color: #377ba8; }
 .logo           { filter: none; vertical-align: middle; width="20" height="20"; }


### PR DESCRIPTION
Via Marko's Github flavoured Markdown extension.

current
![image](https://user-images.githubusercontent.com/172324/147095668-cec0d9cb-ec12-4824-9444-a1278ed826f4.png)

new
![image](https://user-images.githubusercontent.com/172324/147095719-1ffb9246-9220-4939-acad-89208d9c35dd.png)

Requires some discussion as to whether GFM is OK.  

Uses Marko's GFM extension. https://marko-py.readthedocs.io/en/latest/extensions.html#github-flavored-markdown

Marko's GFM collects together a number of extensions: https://github.com/frostming/marko/blob/master/marko/ext/gfm/elements.py