### PR TITLE
Remove inline style, make popup match in light theme

### DIFF
--- a/app/static/css/mobile-dark.css
+++ b/app/static/css/mobile-dark.css
@@ -17,8 +17,12 @@
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Merriweather+Sans&display=swap');
 
+:root {
+    --main-bg: #000;
+}
+
 html            { font-family: 'Noto Sans', sans-serif}
-body            { background: #000000; color: #bfbfbf; overflow-x: hidden;}
+body            { background: var(--main-bg); color: #bfbfbf; overflow-x: hidden;}
 a               { color: #9fc6e0; }
 h1, h2          { color: #bfbfbf; }
 h1, h2          { font-family: 'Merriweather Sans'; margin-top: 0.2em; margin-bottom: 0.2em;}

--- a/app/static/css/screen-dark.css
+++ b/app/static/css/screen-dark.css
@@ -24,6 +24,7 @@
 
     --accent-bg: #2B2B2B;
     --border: #666;
+    --main-bg: #000;
 }
 
 html {
@@ -36,7 +37,7 @@ html {
 }
 
 body {
-    background: #000000;
+    background: var(--main-bg);
     color: #bfbfbf;
     overflow-x: hidden;
     max-width: 60em;

--- a/app/static/css/screen-light.css
+++ b/app/static/css/screen-light.css
@@ -19,9 +19,10 @@
 :root {
     --accent-bg: #F5F7FF;
     --border: #D8DAE1;
+    --main-bg: #eee;
 }
 
-body            { background: #eee; color: #000000; overflow-x: hidden;}
+body            { color: #000000; overflow-x: hidden;}
 a, h1, h2, h3, h4, h5, h6       { color: #377ba8; }
 .logo           { filter: none; vertical-align: middle; width="20" height="20"; }
 

--- a/app/static/js/hover.js
+++ b/app/static/js/hover.js
@@ -24,7 +24,7 @@ $(".wikilink").hover(async function () {
 function showBox(url){
   $.get(url, function (data) {
     if (!locked) return
-    $("#popup").css({ 'top': mouseY, 'left': mouseX, 'background-color': 'black' })
+    $("#popup").css({ 'top': mouseY, 'left': mouseX, 'background-color': 'var(--main-bg)' })
     $("#popup").html(`<div><button onclick='closePopup()'>Close X</button></div>` + data).show()
   });
 }


### PR DESCRIPTION
Using an inline style overriding it needs `!important` so this is nice for user styles and such.

I was thinking of going and refactoring more of the colors into variables if that'd be okay -- makes it easier for people to retheme. 

I didn't have time to get the dev server working tonight -- I'll need to work up a test file sources.yaml -- so this hasn't been tested (except, like, manually verifying that broadly, inline styles can reference variables). 